### PR TITLE
allow const x = require('y') in local scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Then configure the rules you want to use under the rules section.
 ### Options
 
 * `"ignoreModules": true` allow `const foo = require('bar');` at any scope
-  * Sometimes you may want to lazily `require` a module in a function so it doesn't slow down your boot times. Use this option if you want to use `const` for these imports.
+  * Sometimes you may want to lazily `require` a module in a function so it doesn't slow down your boot times, or you want to lazily download a module instead of bundling. Use this option if you want to use `const` for these imports.
 
 ### Possible Conflicts
 

--- a/README.md
+++ b/README.md
@@ -85,6 +85,11 @@ Then configure the rules you want to use under the rules section.
 }
 ```
 
+### Options
+
+* `"ignoreModules": true` allow `const foo = require('bar');` at any scope
+  * Sometimes you may want to lazily `require` a module in a function so it doesn't slow down your boot times. Use this option if you want to use `const` for these imports.
+
 ### Possible Conflicts
 
 This plugin may conflict with other plugins or configs that set `eslint prefer-const`. You can configure the rules to avoid this:

--- a/lib/rules/prefer-let.js
+++ b/lib/rules/prefer-let.js
@@ -62,6 +62,19 @@ module.exports = {
       }).length;
     }
 
+    function isImportStatement(node) {
+      // detect multiple declaration:
+      // `const x = await import('y'), z = 'y';`
+      return !node.declarations.filter(declaration => {
+        let init = declaration.init;
+        if (init.type !== 'AwaitExpression') {
+          return true;
+        }
+        let callee = init.argument.callee;
+        return !(callee && callee.type === 'Import');
+      }).length;
+    }
+
     //----------------------------------------------------------------------
     // Public
     //----------------------------------------------------------------------
@@ -73,7 +86,7 @@ module.exports = {
             message: 'prefer `let` over `var` to declare value bindings',
             node
           });
-        } else if (node.kind !== 'let' && !isTopLevelScope(node) && !(ignoreModules && isRequireStatement(node))) {
+        } else if (node.kind !== 'let' && !isTopLevelScope(node) && !(ignoreModules && (isRequireStatement(node) || isImportStatement(node)))) {
           context.report({
             message: '`const` declaration outside top-level scope',
             node

--- a/lib/rules/prefer-let.js
+++ b/lib/rules/prefer-let.js
@@ -17,12 +17,21 @@ module.exports = {
     },
     fixable: "code",  // or "code" or "whitespace"
     schema: [
-      // fill in your schema
+      {
+        'type': 'object',
+        'properties': {
+          'ignoreModules': {
+            'type': 'boolean',
+          },
+        },
+        'additionalProperties': false
+      }
     ]
   },
 
   create: function(context) {
-    // variables should be defined here
+    let options = context.options[0] || {};
+    let ignoreModules = options.ignoreModules;
 
     //----------------------------------------------------------------------
     // Helpers
@@ -44,6 +53,15 @@ module.exports = {
       return isGlobalScope(node) || isModuleScope(node) || isProgramScope(node);
     }
 
+    function isRequireStatement(node) {
+      // detect multiple declaration:
+      // `const x = require('y'), z = 'y';`
+      return !node.declarations.filter(declaration => {
+        let callee = declaration.init.callee;
+        return !(callee && callee.name === 'require');
+      }).length;
+    }
+
     //----------------------------------------------------------------------
     // Public
     //----------------------------------------------------------------------
@@ -55,7 +73,7 @@ module.exports = {
             message: 'prefer `let` over `var` to declare value bindings',
             node
           });
-        } else if (node.kind !== 'let' && !isTopLevelScope(node)) {
+        } else if (node.kind !== 'let' && !isTopLevelScope(node) && !(ignoreModules && isRequireStatement(node))) {
           context.report({
             message: '`const` declaration outside top-level scope',
             node

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "requireindex": "~1.1.0"
   },
   "devDependencies": {
+    "babel-eslint": "^8.2.6",
     "eslint": "^3.5.0",
     "mocha": "^2.4.5"
   },

--- a/tests/lib/rules/prefer-let.js
+++ b/tests/lib/rules/prefer-let.js
@@ -38,6 +38,10 @@ ruleTester.run("prefer-let", rule, {
       code: `export const AlsoObject = Object;`
     },
     {
+      code: "function y() { const x = require('y'); }",
+      options: [{ ignoreModules: true }]
+    },
+    {
       parserOptions: {
         sourceType: "script"
       },
@@ -81,6 +85,22 @@ ruleTester.run("prefer-let", rule, {
       code: "function y() { var { x, y } = {}; }",
       errors: [{
         message: "prefer `let` over `var` to declare value bindings",
+        type: "VariableDeclaration"
+      }]
+    },
+    {
+      code: "function y() { const x = require('y'); }",
+      errors: [{
+        message: "`const` declaration outside top-level scope",
+        type: "VariableDeclaration"
+      }]
+    },
+    {
+      // multiple declaration test
+      code: "function y() { const x = require('y'), z = 'y'; }",
+      options: [{ ignoreModules: true }],
+      errors: [{
+        message: "`const` declaration outside top-level scope",
         type: "VariableDeclaration"
       }]
     },


### PR DESCRIPTION
This would allow us to use this in ember-cli as mentioned [here](https://github.com/ember-cli/ember-cli/pull/7454#issuecomment-346244766).

I'm open to making this an optional thing, or you could deny if this goes against this package's purpose.